### PR TITLE
Added +2GB file support

### DIFF
--- a/Viola.Core/Dump/Logic/CDump.cs
+++ b/Viola.Core/Dump/Logic/CDump.cs
@@ -5,6 +5,7 @@ using Viola.Core.Launcher.DataClasses;
 using Viola.Core.Utils.General.Logic;
 using Viola.Core.EncryptDecrypt.Logic.Utils;
 using Viola.Core.ViolaLogger.Logic;
+
 namespace Viola.Core.Dump.Logic;
 class CDump
 {
@@ -36,12 +37,12 @@ class CDump
         foreach (var cpk in cpkPaths)
         {
             CLogger.LogInfo($"Extracting {cpk}\n");
-            using var stream = GetAppropriateStream(cpk);
-            
+            using var stream = CGeneralUtils.GetAppropriateStream(cpk);
+
             byte[] magicBuf = new byte[4];
             stream.Read(magicBuf, 0, 4);
             stream.Position = 0;
-            
+
             if (Encoding.UTF8.GetString(magicBuf) != "CPK ")
             {
                 try
@@ -57,10 +58,10 @@ class CDump
                     return;
                 }
             }
-            
+
             using var reader = new CriFsLib().CreateCpkReader(stream, true);
             var files = reader.GetFiles();
-            
+
             foreach (CpkFile file in files)
             {
                 using var extractedFile = reader.ExtractFile(file);

--- a/Viola.Core/Dump/Logic/CDump.cs
+++ b/Viola.Core/Dump/Logic/CDump.cs
@@ -36,7 +36,7 @@ class CDump
         foreach (var cpk in cpkPaths)
         {
             CLogger.LogInfo($"Extracting {cpk}\n");
-            using var stream = GetBestStreamForFile(cpk);
+            using var stream = GetAppropriateStream(cpk);
             
             byte[] magicBuf = new byte[4];
             stream.Read(magicBuf, 0, 4);

--- a/Viola.Core/Utils/General/Logic/CGeneralUtils.cs
+++ b/Viola.Core/Utils/General/Logic/CGeneralUtils.cs
@@ -37,10 +37,10 @@ public class CGeneralUtils
     public static Stream GetAppropriateStream(string path)
     {
         long length = new FileInfo(path).Length;
-    
+
         const long twoGBThreshold = (long)2 * 1024 * 1024 * 1024;
-    
-        if (length < TwoGB)
+
+        if (length < twoGBThreshold)
         {
             return new MemoryStream(File.ReadAllBytes(path));
         }

--- a/Viola.Core/Utils/General/Logic/CGeneralUtils.cs
+++ b/Viola.Core/Utils/General/Logic/CGeneralUtils.cs
@@ -1,5 +1,7 @@
+using System.IO;
 using System.IO.Hashing;
 using System.Text;
+
 namespace Viola.Core.Utils.General.Logic;
 public class CGeneralUtils
 {
@@ -30,6 +32,20 @@ public class CGeneralUtils
         crc32.Append(Encoding.UTF8.GetBytes(data));
         var hash = crc32.GetCurrentHashAsUInt32();
         return hash;
+    }
+
+    public static Stream GetAppropiateStream(string path)
+    {
+        long length = new FileInfo(path).Length;
+    
+        const long twoGBThreshold = (long)2 * 1024 * 1024 * 1024;
+    
+        if (length < TwoGB)
+        {
+            return new MemoryStream(File.ReadAllBytes(path));
+        }
+
+        return new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
     }
 
 }

--- a/Viola.Core/Utils/General/Logic/CGeneralUtils.cs
+++ b/Viola.Core/Utils/General/Logic/CGeneralUtils.cs
@@ -34,7 +34,7 @@ public class CGeneralUtils
         return hash;
     }
 
-    public static Stream GetAppropiateStream(string path)
+    public static Stream GetAppropriateStream(string path)
     {
         long length = new FileInfo(path).Length;
     


### PR DESCRIPTION
Added a method `GetAppropriateStream`, that returns a FileStream for files larger than 2GB in size or a MemoryStream for less than 2GB. Modified CDump.cs file to implement said method.